### PR TITLE
Windows7 compilation

### DIFF
--- a/Hunspell.sln
+++ b/Hunspell.sln
@@ -1,0 +1,20 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libhunspell", "libhunspell.vcxproj", "{53609BB3-D874-465C-AF7B-DF626DB0D89B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Release|Win32 = Release|Win32
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Release|Win32.ActiveCfg = Release|Win32
+		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Release|Win32.Build.0 = Release|Win32
+		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Release|x64.ActiveCfg = Release|x64
+		{53609BB3-D874-465C-AF7B-DF626DB0D89B}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/README
+++ b/README
@@ -3,17 +3,33 @@ ABOUT PYHUNSPELL
 Pyhunspell is a set of Python bindings for the Hunspell spellchecker engine. It
 lets developers load Hunspell dictionaries, check words, get suggestions, add
 new words, etc. It also provides some basic morphological analysis related
-methods. Basic usage instructions are at UsingPyHunspell.
-
-* <http://code.google.com/p/pyhunspell/wiki/UsingPyHunspell>
-* <http://hunspell.sourceforge.net/>
+methods.
 
 INSTALLATION
 ============
-Make sure that python-dev and libhunspell-dev are installed and run the
-following command as root to install pyhunspell:
+Make sure that python-dev and libhunspell-dev are installed.
 
+You can install this package using pip:
+> pip install pyhunspell
+
+Or from source using the following command as root:
 > python setup.py install
+
+USAGE
+=====
+>>> import hunspell
+>>> hobj = hunspell.HunSpell('/usr/share/myspell/en_US.dic', '/usr/share/myspell/en_US.aff')
+>>> hobj.spell('spookie')
+False
+>>> hobj.suggest('spookie')
+['spookier', 'spookiness', 'spooky', 'spook', 'spoonbill']
+>>> hobj.spell('spooky')
+True
+>>> hobj.analyze('linked')
+[' st:link fl:D']
+>>> hobj.stem('linked')
+['link']
+>>> 
 
 LICENSE
 =======

--- a/libhunspell.vcxproj
+++ b/libhunspell.vcxproj
@@ -1,0 +1,152 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{53609BB3-D874-465C-AF7B-DF626DB0D89B}</ProjectGuid>
+    <RootNamespace>Hunspell</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.40219.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)$(Configuration)\$(ProjectName)\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(Configuration)\$(ProjectName)\</IntDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
+    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Release|x64'">AllRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+    <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+    <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <Optimization>Full</Optimization>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <AdditionalIncludeDirectories>..\hunspell;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;HUNSPELL_STATIC;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <StringPooling>true</StringPooling>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
+      <WarningLevel>Level4</WarningLevel>
+      <DebugInformationFormat>
+      </DebugInformationFormat>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Bscmake>
+      <SuppressStartupBanner>false</SuppressStartupBanner>
+    </Bscmake>
+    <Lib>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <Optimization>Full</Optimization>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <AdditionalIncludeDirectories>..\hunspell;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;HUNSPELL_STATIC;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <StringPooling>true</StringPooling>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
+      <WarningLevel>Level4</WarningLevel>
+      <DebugInformationFormat>
+      </DebugInformationFormat>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Bscmake>
+      <SuppressStartupBanner>false</SuppressStartupBanner>
+    </Bscmake>
+    <Lib>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="config.h" />
+    <ClInclude Include="hunspelldll.h" />
+    <ClInclude Include="..\hunspell\affentry.hxx" />
+    <ClInclude Include="..\hunspell\affixmgr.hxx" />
+    <ClInclude Include="..\hunspell\atypes.hxx" />
+    <ClInclude Include="..\hunspell\baseaffix.hxx" />
+    <ClInclude Include="..\hunspell\csutil.hxx" />
+    <ClInclude Include="..\hunspell\dictmgr.hxx" />
+    <ClInclude Include="..\hunspell\filemgr.hxx" />
+    <ClInclude Include="..\hunspell\hashmgr.hxx" />
+    <ClInclude Include="..\hunspell\htypes.hxx" />
+    <ClInclude Include="..\hunspell\hunspell.h" />
+    <ClInclude Include="..\hunspell\hunspell.hxx" />
+    <ClInclude Include="..\hunspell\hunzip.hxx" />
+    <ClInclude Include="..\hunspell\langnum.hxx" />
+    <ClInclude Include="..\hunspell\phonet.hxx" />
+    <ClInclude Include="..\hunspell\replist.hxx" />
+    <ClInclude Include="..\hunspell\suggestmgr.hxx" />
+    <ClInclude Include="..\hunspell\w_char.hxx" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="Hunspell.rc" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="hunspelldll.c">
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">CompileAsCpp</CompileAs>
+      <CompileAs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">CompileAsCpp</CompileAs>
+    </ClCompile>
+    <ClCompile Include="..\hunspell\affentry.cxx" />
+    <ClCompile Include="..\hunspell\affixmgr.cxx" />
+    <ClCompile Include="..\hunspell\csutil.cxx" />
+    <ClCompile Include="..\hunspell\dictmgr.cxx" />
+    <ClCompile Include="..\hunspell\filemgr.cxx" />
+    <ClCompile Include="..\hunspell\hashmgr.cxx" />
+    <ClCompile Include="..\hunspell\hunspell.cxx" />
+    <ClCompile Include="..\hunspell\hunzip.cxx" />
+    <ClCompile Include="..\hunspell\phonet.cxx" />
+    <ClCompile Include="..\hunspell\replist.cxx" />
+    <ClCompile Include="..\hunspell\suggestmgr.cxx" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/setup.py
+++ b/setup.py
@@ -11,21 +11,23 @@ the Free Software Foundation, either version 3 of the License, or
 
 PyHunspell is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with PyHunspell. If not, see <http://www.gnu.org/licenses/>.
+along with PyHunspell.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 from distutils.core import setup, Extension
 
 main = Extension('hunspell',
-                 define_macros=[('_LINUX', None)],
-                 libraries=['hunspell'],
-                 include_dirs=['/usr/include/hunspell'],
+                 define_macros=[('HUNSPELL_STATIC', None)],
+#                 library_dirs=['V:/hunspell-1.3.3/src/win_api/Release/libhunspell'],
+                 library_dirs=['V:/hunspell-1.3.3/src/win_api/x64/Release/libhunspell'],
+                 libraries=['libhunspell'],
+                 include_dirs=['V:/hunspell-1.3.3/src/hunspell'],
                  sources=['hunspell.c'],
-                 extra_compile_args=['-Wall'])
+                 extra_compile_args=['/MT'])
 
 setup(name="hunspell",
       version="0.3.2",

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,11 @@ the Free Software Foundation, either version 3 of the License, or
 
 PyHunspell is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with PyHunspell.  If not, see <http://www.gnu.org/licenses/>.
+along with PyHunspell. If not, see <http://www.gnu.org/licenses/>.
 """
 
 from distutils.core import setup, Extension


### PR DESCRIPTION
I contracted with an experienced Windows developer to prepare pyhunspell for use with Python 3.4 on Windows 7 64-bit. The following are his notes. The files in this pull request are the changes he made to do this. I have tested (not exhaustively) the resulting hunspell.pyd with Python 3.4 on Win7_amd64. Note a one-line commented-out change in setup.py to do a 32-bit compile.

Building hunspell:
1. I used the provided sln and vcproj in src\win_api, upgraded them in VS2010.
2. Added a x64 solution platform.
3. Corrected Output Directory and Intermediate directory for x64 platform (so they don't collide with binaries build for Win32) for the libhunspell project.
4. Corrected target machine setting for both Win32 and x64 Release configurations for libhunspell (other configurations don't matter for building pyhunspell). Librarian > General > Target Machine.
5. Did a batch build of both the Release Win32 and Release x64 libhunspell configurations.

Building pyhunspell:
1. Changed _LINUX in 'define_macros' to HUNSPELL_STATIC in setup.py.
2. Added new 'library_dirs', to point to the build path (manually changed depending on if building for x86 or x64).
3. Changed hunspell in 'libraries' to libhunspell in setup.py, due to platform differences.
4. Changed -Wall in 'extra_compile_args' to /MT, since hunspell is being linked statically.
5. Ran python.exe setup.py bdist_dumb to generate a flat distribution zip file.