### PR TITLE
Convert to Markdown syntax.

### DIFF
--- a/README
+++ b/README
@@ -1,38 +1,44 @@
 ABOUT PYHUNSPELL
 ================
-Pyhunspell is a set of Python bindings for the Hunspell spellchecker engine. It
-lets developers load Hunspell dictionaries, check words, get suggestions, add
-new words, etc. It also provides some basic morphological analysis related
-methods.
+
+**pyhunspell** is a set of Python bindings for the Hunspell spellchecker 
+engine. It lets developers load Hunspell dictionaries, check words, get 
+suggestions, add new words, etc. It also provides some basic morphological 
+analysis related methods.
 
 INSTALLATION
 ============
-Make sure that python-dev and libhunspell-dev are installed.
+
+Make sure that `python-dev` and `libhunspell-dev` are installed.
 
 You can install this package using pip:
-> pip install hunspell
+
+    pip install hunspell
 
 Or from source using the following command as root:
-> python setup.py install
+
+    python setup.py install
 
 USAGE
 =====
->>> import hunspell
->>> hobj = hunspell.HunSpell('/usr/share/myspell/en_US.dic', '/usr/share/myspell/en_US.aff')
->>> hobj.spell('spookie')
-False
->>> hobj.suggest('spookie')
-['spookier', 'spookiness', 'spooky', 'spook', 'spoonbill']
->>> hobj.spell('spooky')
-True
->>> hobj.analyze('linked')
-[' st:link fl:D']
->>> hobj.stem('linked')
-['link']
->>> 
+
+    >>> import hunspell
+    >>> hobj = hunspell.HunSpell('/usr/share/myspell/en_US.dic', '/usr/share/myspell/en_US.aff')
+    >>> hobj.spell('spookie')
+    False
+    >>> hobj.suggest('spookie')
+    ['spookier', 'spookiness', 'spooky', 'spook', 'spoonbill']
+    >>> hobj.spell('spooky')
+    True
+    >>> hobj.analyze('linked')
+    [' st:link fl:D']
+    >>> hobj.stem('linked')
+    ['link']
+    >>> 
 
 LICENSE
 =======
+
 PyHunspell itself is licensed under the LGPL version 3 or later, see
 lgpl-3.0.txt and gpl-3.0.txt. The files in the debian/ directory and setup.py
 are licensed under the GPL version 3.


### PR DESCRIPTION
I formatted `README` with Markdown, since the project is now on GitHub and that syntax is favoured. The text file is still readable regardless of the markings, which is the intention of Markdown anyway.

Cheers.