### PR TITLE
Fix encoding problem in HunSpell.suggest method

### DIFF
--- a/hunspell.cpp
+++ b/hunspell.cpp
@@ -165,7 +165,7 @@ HunSpell_suggest(HunSpell * self, PyObject *args)
     PyMem_Free(word);
 
     for (i = 0, ret = 0; !ret && i < num_slist; i++) {
-        pystr = PyUnicode_FromString(slist[i]);
+        pystr = PyBytes_FromString(slist[i]);
         if (!pystr)
             break;
         ret = PyList_Append(slist_list, pystr);


### PR DESCRIPTION
Fix/workaround for #32:
```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb6 in position 0: invalid start byte
```