### PR TITLE
Should fix #39

### DIFF
--- a/hunspell.cpp
+++ b/hunspell.cpp
@@ -97,6 +97,7 @@ HunSpell_init(HunSpell * self, PyObject *args, PyObject *kwds)
 static void
 HunSpell_dealloc(HunSpell * self)
 {
+    delete self->handle;
     Py_TYPE(self)->tp_free((PyObject *)self);
 }
 


### PR DESCRIPTION
To be tested on a real environment using the package.
I just tracked down the memory leak and tried to fix it.
Worked for all my tests on it but...

The trick was that in the init of hunspell, it create an object without a pointer on it. So it won't be catched by the gc if we do not notify it to do so.