### PR TITLE
give README.md content_type in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(name="hunspell",
       version="0.5.5",
       description="Module for the Hunspell spellchecker engine",
       long_description=open('README.md').read(),
+      long_description_content_type="text/markdown",  # so PyPI renders it properly
       author="Benoît Latinier",
       author_email="benoit@latinier.fr",
       url="http://github.com/blatinier/pyhunspell",


### PR DESCRIPTION
README.md rendering in PyPI is currently broken because PyPI doesn't know it's Markdown. Without the content type information it will assume it's rst. This commit provide the correct content type