### PR TITLE
Function to automatically detect MacOS paths

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,21 @@ along with PyHunspell. If not, see <http://www.gnu.org/licenses/>.
 from setuptools import setup, Extension
 import platform
 import os
+import subprocess
+import re
+
+def get_mac_include_dirs():
+    cmd = "brew list --versions hunspell | tr ' ' '\n' | tail -1"
+    ps = subprocess.Popen(cmd,shell=True,stdout=subprocess.PIPE,stderr=subprocess.STDOUT)
+    output = ps.communicate()[0]
+    hun_ver = output.decode('utf-8')
+    hun_ver = hun_ver.strip()
+    hmv = re.split(r'_',hun_ver)
+    hun_maj_ver = hmv[0] 
+    hun_path = '/usr/local/Cellar/hunspell/' + hun_ver + '/include/hunspell'
+    symlink = 'ln -s /usr/local/Cellar/hunspell/' + hun_ver + '/lib/libhunspell-' + hun_maj_ver + '.dylib /usr/local/Cellar/hunspell/' + hun_ver + '/lib/libhunspell.dylib'
+    os.system(symlink)
+    return hun_path
 
 def get_linux_include_dirs():
     return ['{}/hunspell'.format(d) for d in os.getenv('INCLUDE_PATH', '').split(':') if d]
@@ -36,7 +51,7 @@ if platform.system() == "Windows":
 elif platform.system() == "Darwin":
     main_module_kwargs['define_macros'] = [('_LINUX', None)]
     main_module_kwargs['libraries'] = ['hunspell']
-    main_module_kwargs['include_dirs'] = '/usr/local/Cellar/hunspell/1.6.2/include/hunspell',
+    main_module_kwargs['include_dirs'] = get_mac_include_dirs(),
     main_module_kwargs['extra_compile_args'] = ['-Wall']
 else:
     main_module_kwargs['define_macros'] = [('_LINUX', None)]

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ if platform.system() == "Windows":
     main_module_kwargs['library_dirs'] = ['V:/hunspell-1.3.3/src/win_api/x64/Release/libhunspell']
     main_module_kwargs['extra_compile_args'] = ['/MT']
 elif platform.system() == "Darwin":
-    main_module_kwargs['sources'] = [
     main_module_kwargs['define_macros'] = [('_LINUX', None)]
     main_module_kwargs['libraries'] = ['hunspell']
     main_module_kwargs['include_dirs'] = get_mac_include_dirs(),

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def get_mac_include_dirs():
     hun_ver = output.decode('utf-8')
     hun_ver = hun_ver.strip()
     hmv = re.split(r'_',hun_ver)
-    hun_maj_ver = hmv[0] 
+    hun_maj_ver = hmv[0]
     hun_path = '/usr/local/Cellar/hunspell/' + hun_ver + '/include/hunspell'
     symlink = 'ln -s /usr/local/Cellar/hunspell/' + hun_ver + '/lib/libhunspell-' + hun_maj_ver + '.dylib /usr/local/Cellar/hunspell/' + hun_ver + '/lib/libhunspell.dylib'
     os.system(symlink)
@@ -49,6 +49,7 @@ if platform.system() == "Windows":
     main_module_kwargs['library_dirs'] = ['V:/hunspell-1.3.3/src/win_api/x64/Release/libhunspell']
     main_module_kwargs['extra_compile_args'] = ['/MT']
 elif platform.system() == "Darwin":
+    main_module_kwargs['sources'] = [
     main_module_kwargs['define_macros'] = [('_LINUX', None)]
     main_module_kwargs['libraries'] = ['hunspell']
     main_module_kwargs['include_dirs'] = get_mac_include_dirs(),


### PR DESCRIPTION
Added in a function that:
* Grabs the latest installed hunspell version (brew)
* Grabs the major version (anything before "_" in the version number)
* Constructs the path for use in the include path
* Constructs the symlink that people seem to have to run post install