### PR TITLE
fix setup.py libraries and includes for macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,8 @@ if platform.system() == "Windows":
     main_module_kwargs['extra_compile_args'] = ['/MT']
 elif platform.system() == "Darwin":
     main_module_kwargs['define_macros'] = [('_LINUX', None)]
-    main_module_kwargs['libraries'] = ['hunspell']
-    main_module_kwargs['include_dirs'] = '/usr/local/Cellar/hunspell/1.6.2/include/hunspell',
+    main_module_kwargs['libraries'] = [os.popen("pkg-config --libs-only-l hunspell").read()[2:].strip()]
+    main_module_kwargs['include_dirs'] = '/usr/local/include/hunspell',
     main_module_kwargs['extra_compile_args'] = ['-Wall']
 else:
     main_module_kwargs['define_macros'] = [('_LINUX', None)]


### PR DESCRIPTION
/usr/local/include/hunspell is automatically linked to /usr/local/Cellar/hunspell/x.x.x/include/hunspell by homebrew. pkg-config --libs-only-l hunspell prints "-lhunspell-x.x\n" to the output then we trim it to become "hunspell-x.x"