### PR TITLE
Bump Hunspell Version to 1.7 for MacOS build 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,8 @@ if platform.system() == "Windows":
     main_module_kwargs['extra_compile_args'] = ['/MT']
 elif platform.system() == "Darwin":
     main_module_kwargs['define_macros'] = [('_LINUX', None)]
-    main_module_kwargs['libraries'] = ['hunspell']
-    main_module_kwargs['include_dirs'] = '/usr/local/Cellar/hunspell/1.6.2/include/hunspell',
+    main_module_kwargs['libraries'] = ['hunspell-1.7']
+    main_module_kwargs['include_dirs'] = '/usr/local/Cellar/hunspell/1.7.0_2/include/hunspell',
     main_module_kwargs['extra_compile_args'] = ['-Wall']
 else:
     main_module_kwargs['define_macros'] = [('_LINUX', None)]


### PR DESCRIPTION
Resolves MacOS installation of python bindings.  See #81